### PR TITLE
fix: special-case media-playlist-item's type attr

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,8 @@
 <html>
   <head>
     <!-- <script type="module" src="index.js"></script> -->
-    <script type="module" src="https://unpkg.com/hls-video-element@0"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/hls-video-element@0/+esm"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@mux/mux-video@0/+esm"></script>
     <script type="module" src="../dist/media-playlist.js"></script>
 
     <style>
@@ -17,8 +18,9 @@
   <h1>&lt;media-playlist&gt;</h1>
 
   <media-playlist loop>
-    <media-playlist-item type="video" src="http://techslides.com/demos/sample-videos/small.mp4"></media-playlist-item>
-    <media-playlist-item type="hls-video" crossorigin src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8"></media-playlist-item>
+    <media-playlist-item type="video" controls src="http://techslides.com/demos/sample-videos/small.mp4"></media-playlist-item>
+    <media-playlist-item type="hls-video" controlscrossorigin src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8"></media-playlist-item>
+    <media-playlist-item type="mux-video" controls playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"></media-playlist-item>
     <media-playlist-item type="audio" controls src="https://dl.espressif.com/dl/audio/ff-16b-2c-44100hz.mp3"></media-playlist-item>
   </media-playlist>
 

--- a/index.js
+++ b/index.js
@@ -220,6 +220,10 @@ class MediaPlaylist extends HTMLElement {
       // Copy attrs from the playlist item to the media
       for (let i = 0, len = playlistItem.attributes.length; i < len; i++) {
         const attr = playlistItem.attributes[i];
+
+        // skip type attr as that's special for media-playlist-item
+        if (attr.nodeName === 'type') continue;
+
         mediaElement.setAttribute(attr.nodeName, attr.value);
       }
 
@@ -311,10 +315,10 @@ class MediaPlaylist extends HTMLElement {
   set defaultPlaybackRate(value) {}
 
   get ended() {}
-  
+
   get muted() {}
   set muted(value) {}
-  
+
   get src() {}
   set src(value) {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,11 +987,6 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
-custom-video-element@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/custom-video-element/-/custom-video-element-0.0.2.tgz#aead266cef4ad6bc046e269472744ff76e4d7e43"
-  integrity sha512-kkuWKjaHZfy6lVwNlbjbgbXxkQLsPbCARUwDiZyfdPQ2nbDJMuuaQUWDUpxhpkc3b3M30eqxjHbz86gfQyL9aQ==
-
 date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"


### PR DESCRIPTION
The type attribute is a special attribute to tell media-playlist which media-slotted element to use.

Some media-slotted elements might use a `type` attribute for something and so we probably don't want to copy it over.